### PR TITLE
Booking cards now display the correct ghost images

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,7 +21,12 @@
       <div class="tab-pane fade show active" id="future" role="tabpanel" aria-labelledby="future-tab">
         <% @future_bookings.each do |booking| %>
         <div class="card-product">
-          <img src="https://source.unsplash.com/1600x900/?ghost,spooky" />
+          <% if booking.ghost.photo.attached? %>
+            <%= cl_image_tag booking.ghost.photo.key, crop: :fill %>
+          <% else %>
+            <img src="https://source.unsplash.com/1600x900/?ghost,spooky" />
+          <% end %>
+
           <div class="card-product-infos">
             <h2><%= booking.ghost.name %></h2>
             <p><%= "Dates: #{booking.start_date} - #{booking.end_date}" %></p>


### PR DESCRIPTION
The booking cards now display the ghost images instead of the random unsplash ones on the user show page. 